### PR TITLE
Mock OpenAI API in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import sys
+import pathlib as _pathlib
+sys.path.append(str(_pathlib.Path(__file__).resolve().parent.parent))
+import pytest
+from unittest.mock import MagicMock
+
+@pytest.fixture
+def mock_openai(monkeypatch):
+    """Patch the OpenAI client to avoid real API calls."""
+    mock_client = MagicMock()
+    monkeypatch.setattr("src.services.openai_responses_client.OpenAI", lambda *args, **kwargs: mock_client)
+    monkeypatch.setattr("src.pipeline.base_orchestrator.OpenAI", lambda *args, **kwargs: mock_client)
+    monkeypatch.setattr("openai.OpenAI", lambda *args, **kwargs: mock_client)
+    return mock_client
+
+@pytest.fixture
+def mock_responses_success(monkeypatch):
+    """Patch ResponsesClient methods to return a deterministic response."""
+    from src.services.openai_responses_client import ResponsesClient
+    mock_response = MagicMock()
+    mock_response.output = MagicMock(message=MagicMock(content="mocked response"))
+
+    def _create_response(self, *args, **kwargs):  # noqa: D401
+        return mock_response
+
+    def _create_simple_response(self, *args, **kwargs):  # noqa: D401
+        return "mocked response"
+
+    monkeypatch.setattr(ResponsesClient, "create_response", _create_response)
+
+    monkeypatch.setattr(ResponsesClient, "create_simple_response", _create_simple_response)
+    return mock_response
+
+@pytest.fixture
+def mock_responses_error(monkeypatch):
+    """Patch ResponsesClient to raise an error."""
+    from src.services.openai_responses_client import ResponsesClient
+
+    def _raise(self, *args, **kwargs):  # noqa: D401
+        raise Exception("Mock API error")
+
+    monkeypatch.setattr(ResponsesClient, "create_response", _raise)
+    monkeypatch.setattr(ResponsesClient, "create_simple_response", _raise)

--- a/tests/test_content_writer.py
+++ b/tests/test_content_writer.py
@@ -1,105 +1,16 @@
-#!/usr/bin/env python3
-"""Test the content writer agent directly to debug article generation issues."""
+import sys
+import pathlib as _pathlib
+sys.path.append(str(_pathlib.Path(__file__).resolve().parent.parent))
+from src.agents.writing_agents import ContentWriterAgent
 
-import asyncio
-from agents import Runner
-from src.agents import content_writer
-from src.tools.function_tools import write_file
 
-async def test_content_writer():
-    """Test the content writer with a focused prompt."""
-    
-    # Create the agent
-    agent = content_writer.create()
-    agent.tools.extend([write_file])
-    
-    # Sample synthesis data
-    synthesis = """
-    Index funds offer institutional investors significant advantages:
-    
-    1. Cost Efficiency: Average expense ratio 0.06% vs 0.76% for active funds (Morningstar 2024)
-    2. Performance: 90% of active funds underperform their benchmark over 15 years (S&P Dow Jones 2024)
-    3. Tax Efficiency: Lower turnover reduces capital gains distributions
-    4. Transparency: Holdings are public and updated daily
-    5. Scalability: Can invest billions without market impact
-    
-    Key statistics:
-    - $11.8 trillion in index fund assets globally (ICI 2024)
-    - 45% of US equity fund assets are now passive (Morningstar)
-    - Average annual cost savings: 70 basis points
-    
-    Dakota articles to reference:
-    - "The Rise of Passive Investing" - explores shift from active to passive
-    - "Cost Analysis for Institutional Portfolios" - detailed fee comparisons
-    - "Building Core Satellite Strategies" - using index funds as portfolio foundation
-    """
-    
-    prompt = f"""You are the Dakota Content Writer. Create a comprehensive Learning Center article.
+def test_content_writer_success(mock_openai, mock_responses_success):
+    agent = ContentWriterAgent()
+    result = agent.query_llm("Write an intro")
+    assert result == "mocked response"
 
-MANDATORY REQUIREMENTS:
-1. Use the EXACT template from your instructions
-2. Minimum 1,750 words (this is critical - aim for 2,000+)
-3. Include proper YAML frontmatter with ALL fields:
-   - title
-   - date: 2025-08-09
-   - word_count: [actual count]
-   - reading_time: [calculate based on 250 words/minute]
-4. Include 10+ inline citations using [Source Name](URL) format
-5. Follow the section structure EXACTLY as specified
 
-Topic: Benefits of Index Fund Investing for Institutional Investors
-
-Use this research:
-{synthesis}
-
-Example URLs to use in citations:
-- https://www.morningstar.com/articles/1234567/index-fund-growth
-- https://www.spglobal.com/spdji/en/research/article/spiva-us-scorecard
-- https://www.ici.org/research/stats/factbook
-- https://www.vanguard.com/institutional/insights/index-advantage
-- https://www.blackrock.com/institutional/index-investing
-- https://www.ssga.com/institutional/etfs/insights/cost-matters
-- https://www.fidelity.com/institutional/index-fund-strategies
-- https://www.investmentcompany.org/research/passive-trends
-- https://www.ft.com/content/institutional-index-adoption
-- https://www.wsj.com/articles/index-funds-institutional-growth
-
-Write the COMPLETE article now. Save to: test_article.md"""
-
-    # Run the agent
-    print("Testing content writer...")
-    result = await Runner.run(agent, prompt)
-    
-    # Print full output for debugging
-    print(f"\nFull agent output:")
-    print("=" * 80)
-    print(result.final_output)
-    print("=" * 80)
-    
-    # Check the messages for errors
-    if result.messages:
-        print(f"\nNumber of messages: {len(result.messages)}")
-        for i, msg in enumerate(result.messages):
-            print(f"\nMessage {i}: {msg.role}")
-            if hasattr(msg, 'content') and msg.content:
-                print(f"Content preview: {str(msg.content)[:200]}...")
-    
-    # Check what was written
-    import os
-    if os.path.exists("test_article.md"):
-        with open("test_article.md", "r") as f:
-            content = f.read()
-            word_count = len(content.split())
-            print(f"\nArticle generated:")
-            print(f"- Word count: {word_count}")
-            print(f"- Has YAML frontmatter: {'---' in content[:10]}")
-            print(f"- Has Key Insights: {'Key Insights at a Glance' in content}")
-            print(f"- Has Key Takeaways: {'Key Takeaways' in content}")
-            print(f"- Citation count: {content.count('](http')}")
-    else:
-        print("\nNo article file was created!")
-        print("Current directory:", os.getcwd())
-        print("Files in directory:", os.listdir("."))
-
-if __name__ == "__main__":
-    asyncio.run(test_content_writer())
+def test_content_writer_error(mock_openai, mock_responses_error):
+    agent = ContentWriterAgent()
+    result = agent.query_llm("Write an intro")
+    assert result == "Error: Mock API error"

--- a/tests/test_full_system.py
+++ b/tests/test_full_system.py
@@ -1,81 +1,15 @@
-#!/usr/bin/env python3
-"""
-Test the full production system with all agents
-"""
-import asyncio
-import os
 import sys
-sys.path.append('src')
+import pathlib as _pathlib
+sys.path.append(str(_pathlib.Path(__file__).resolve().parent.parent))
+from src.pipeline.base_orchestrator import BaseOrchestrator
+import pytest
 
-from dotenv import load_dotenv
-from src.pipeline.chat_orchestrator import ChatOrchestrator
+def test_orchestrator_create_response_success(mock_openai, mock_responses_success):
+    orchestrator = BaseOrchestrator()
+    response = orchestrator.create_response("hello")
+    assert response.output.message.content == "mocked response"
 
-load_dotenv()
-
-async def test_full_system():
-    """Run the complete article generation pipeline"""
-    
-    # Configuration
-    topic = "Top Private Equity Firms in Dallas 2025"
-    
-    print("🚀 TESTING FULL PRODUCTION SYSTEM")
-    print("="*60)
-    print(f"Topic: {topic}")
-    print("\nThis will run ALL agents with real templates:")
-    print("- Web Researcher")
-    print("- KB Researcher") 
-    print("- Research Synthesizer")
-    print("- Content Writer")
-    print("- Fact Checker")
-    print("- SEO Specialist")
-    print("- Social Promoter")
-    print("- Metadata Generator")
-    print("- And more...")
-    print("="*60)
-    
-    # Initialize orchestrator with relaxed validation for testing
-    orchestrator = ChatOrchestrator(
-        min_words=500,  # Lower for testing
-        min_sources=3,   # Lower for testing
-        max_iterations=2  # Fewer iterations
-    )
-    
-    try:
-        # Initialize all agents
-        print("\n📝 Initializing agents...")
-        await orchestrator.initialize_agents()
-        
-        # Run the full pipeline
-        print("\n🔄 Running full pipeline with all agents...")
-        results = await orchestrator.generate_article(topic)
-        
-        if results["status"] == "success":
-            print("\n✅ SUCCESS! Article generated with full pipeline")
-            print(f"\nOutput directory: {results.get('output_dir', 'output/')}")
-            
-            # Show what was created
-            print("\nGenerated files:")
-            output_dir = results.get('output_dir', '')
-            if output_dir and os.path.exists(output_dir):
-                for file in os.listdir(output_dir):
-                    print(f"  - {file}")
-            
-            # Show article preview
-            article_path = os.path.join(output_dir, "article.md") if output_dir else None
-            if article_path and os.path.exists(article_path):
-                with open(article_path, 'r') as f:
-                    content = f.read()
-                    print(f"\n📄 Article Preview ({len(content.split())} words):")
-                    print("-"*40)
-                    print(content[:500] + "...")
-        else:
-            print(f"\n❌ Generation failed: {results.get('error', 'Unknown error')}")
-            
-    except Exception as e:
-        print(f"\n❌ Error: {e}")
-        import traceback
-        traceback.print_exc()
-
-if __name__ == "__main__":
-    # Run the async function
-    asyncio.run(test_full_system())
+def test_orchestrator_create_response_error(mock_openai, mock_responses_error):
+    orchestrator = BaseOrchestrator()
+    with pytest.raises(Exception, match="Mock API error"):
+        orchestrator.create_response("hello")


### PR DESCRIPTION
## Summary
- Add pytest fixtures to mock OpenAI and ResponsesClient and avoid network calls
- Replace real API interactions in tests with deterministic mocks
- Test agent and orchestrator behavior for both success and error responses

## Testing
- `pytest tests/test_content_writer.py tests/test_full_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62a459b4c832ea111bfd28197f193