### PR TITLE
Refactor models to Pydantic and add validation tests

### DIFF
--- a/src/agents/orchestrator.py
+++ b/src/agents/orchestrator.py
@@ -108,7 +108,7 @@ class OrchestratorAgent(BaseAgent):
         pipeline_id = f"pipeline_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         self.current_pipeline = {
             "id": pipeline_id,
-            "request": request.dict() if hasattr(request, 'dict') else request,
+            "request": request.model_dump() if hasattr(request, "model_dump") else request,
             "status": "in_progress",
             "phases": {},
             "start_time": datetime.now().isoformat()
@@ -500,11 +500,11 @@ def create_article_with_multi_agent_system(request: ArticleRequest) -> ArticleRe
         metadata_dict.setdefault("related_topics", [])
         metadata_dict.setdefault("seo_title", metadata_dict.get("title", ""))
         metadata_dict.setdefault("publication_date", datetime.now().strftime("%Y-%m-%d"))
-        
+
         return ArticleResponse(
             success=True,
             article=response.payload["article"],
-            metadata=MetadataGeneration(**metadata_dict),
+            metadata=MetadataGeneration.model_validate(metadata_dict),
             quality_metrics={
                 "quality_score": response.payload.get("quality_score", 0),
                 "phases_completed": response.payload.get("phases_completed", []),

--- a/src/models.py
+++ b/src/models.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
+
 """
-Data models for the article generation system
+Data models for the article generation system.
 """
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Any
 from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 
-@dataclass
-class ArticleRequest:
-    """Request model for article generation"""
+class ArticleRequest(BaseModel):
+    """Request model for article generation."""
+
     topic: str
     word_count: int = 2000
     audience: str = "institutional investors and financial professionals"
@@ -17,28 +20,11 @@ class ArticleRequest:
     include_metadata: bool = True
     include_social: bool = True
     include_summary: bool = True
-    
 
-@dataclass
-class ArticleResponse:
-    """Response model for generated articles"""
-    success: bool
-    article: str  # Changed from article_content to match usage
-    metadata: Optional['MetadataGeneration'] = None  # Forward reference
-    word_count: Optional[int] = None
-    summary: Optional[str] = None
-    social_posts: Optional[Dict[str, str]] = None
-    fact_check_results: Optional[Dict[str, Any]] = None
-    sources: Optional[List[Dict[str, str]]] = None
-    generation_time: Optional[float] = None
-    output_directory: Optional[str] = None
-    error: Optional[str] = None
-    quality_metrics: Optional[Dict[str, Any]] = None
-    
 
-@dataclass
-class MetadataGeneration:
-    """Metadata for article generation"""
+class MetadataGeneration(BaseModel):
+    """Metadata for article generation."""
+
     title: str
     description: str
     keywords: List[str]
@@ -52,26 +38,39 @@ class MetadataGeneration:
     publication_date: str
     author: str = "Dakota Learning Center"
     content_type: str = "article"
-    
 
-@dataclass
-class ResearchResult:
-    """Result from research operations"""
+
+class ArticleResponse(BaseModel):
+    """Response model for generated articles."""
+
+    success: bool
+    article: str
+    metadata: Optional[MetadataGeneration] = None
+    word_count: Optional[int] = None
+    summary: Optional[str] = None
+    social_posts: Optional[Dict[str, str]] = None
+    fact_check_results: Optional[Dict[str, Any]] = None
+    sources: Optional[List[Dict[str, str]]] = None
+    generation_time: Optional[float] = None
+    output_directory: Optional[str] = None
+    error: Optional[str] = None
+    quality_metrics: Optional[Dict[str, Any]] = None
+
+
+class ResearchResult(BaseModel):
+    """Result from research operations."""
+
     topic: str
     findings: List[Dict[str, Any]]
     sources: List[Dict[str, str]]
     key_insights: List[str]
     statistics: List[Dict[str, Any]]
-    timestamp: str = None
-    
-    def __post_init__(self):
-        if not self.timestamp:
-            self.timestamp = datetime.now().isoformat()
+    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
 
 
-@dataclass
-class ValidationResult:
-    """Result from content validation"""
+class ValidationResult(BaseModel):
+    """Result from content validation."""
+
     is_valid: bool
     word_count: int
     source_count: int
@@ -79,11 +78,11 @@ class ValidationResult:
     issues: List[str]
     recommendations: List[str]
     accuracy_score: float = 0.0
-    
 
-@dataclass
-class AgentTask:
-    """Task assignment for agents"""
+
+class AgentTask(BaseModel):
+    """Task assignment for agents."""
+
     task_id: str
     task_type: str
     description: str
@@ -92,11 +91,11 @@ class AgentTask:
     deadline: Optional[str] = None
     assigned_to: Optional[str] = None
     status: str = "pending"
-    
 
-@dataclass
-class AgentResponse:
-    """Standard response from agents"""
+
+class AgentResponse(BaseModel):
+    """Standard response from agents."""
+
     agent_id: str
     task_id: str
     status: str

--- a/src/pipeline/multi_agent_orchestrator.py
+++ b/src/pipeline/multi_agent_orchestrator.py
@@ -66,7 +66,7 @@ class MultiAgentPipelineOrchestrator:
                 result = {
                     "success": True,
                     "article": response.article,
-                    "metadata": response.metadata.dict() if hasattr(response.metadata, 'dict') else response.metadata,
+                    "metadata": response.metadata.model_dump() if hasattr(response.metadata, "model_dump") else response.metadata,
                     "output_path": output_path,
                     "word_count": len(response.article.split()),
                     "quality_metrics": getattr(response, 'quality_metrics', {}),
@@ -136,7 +136,7 @@ class MultiAgentPipelineOrchestrator:
         
         # Save metadata separately
         metadata_path = output_path.replace('.md', '_metadata.json')
-        metadata_dict = response.metadata.dict() if hasattr(response.metadata, 'dict') else response.metadata
+        metadata_dict = response.metadata.model_dump() if hasattr(response.metadata, "model_dump") else response.metadata
         
         # Add quality metrics if available
         if hasattr(response, 'quality_metrics'):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,49 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from src.models import ArticleRequest, MetadataGeneration
+
+
+def test_article_request_validation():
+    # topic must be a string
+    with pytest.raises(ValidationError):
+        ArticleRequest(topic=123)
+
+
+def test_metadata_generation_serialization():
+    metadata = MetadataGeneration(
+        title="Test",
+        description="Desc",
+        keywords=["a", "b"],
+        category="Cat",
+        target_audience="Investors",
+        read_time_minutes=5,
+        key_takeaways=["k1"],
+        related_topics=["t1"],
+        seo_title="SEO Title",
+        seo_description="SEO Desc",
+        publication_date="2024-01-01",
+    )
+    json_str = metadata.model_dump_json()
+    data = json.loads(json_str)
+    assert data["title"] == "Test"
+
+
+def test_metadata_generation_validation_error():
+    # keywords should be a list, not a string
+    with pytest.raises(ValidationError):
+        MetadataGeneration(
+            title="T",
+            description="D",
+            keywords="not a list",
+            category="Cat",
+            target_audience="Investors",
+            read_time_minutes="ten",
+            key_takeaways=[],
+            related_topics=[],
+            seo_title="SEO",
+            seo_description="SEO",
+            publication_date="2024-01-01",
+        )


### PR DESCRIPTION
## Summary
- Replace dataclasses with Pydantic BaseModels for request/response, metadata, and agent models
- Update orchestrator and pipeline to use `model_dump`/`model_validate`
- Add unit tests for model validation and JSON serialization

## Testing
- `PYTHONPATH=$PWD pytest tests/test_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62a5f545c832e869cb449a09e1622