### PR TITLE
feat: add real web search service

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,12 @@ load_dotenv()
 # Vector Store id for File Search (optional)
 VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID", "").strip() or None
 
+# Web search configuration
+WEB_SEARCH_API_KEY = os.getenv("WEB_SEARCH_API_KEY", "").strip()
+WEB_SEARCH_API_ENDPOINT = os.getenv(
+    "WEB_SEARCH_API_ENDPOINT", "https://google.serper.dev/search"
+).strip()
+
 # Default models (best-for-cost mix; override via .env)
 DEFAULT_MODELS = {
     "default": os.getenv("DEFAULT_MODEL", "gpt-5"),

--- a/src/services/web_search.py
+++ b/src/services/web_search.py
@@ -1,34 +1,127 @@
+"""Web search service using external provider.
+
+This module integrates with a configurable web search API (e.g. Serper or
+Bing) to retrieve search results. Results are normalized into a common
+structure so the rest of the application can consume them easily.
 """
-Web Search Service
-Placeholder for web search functionality
-"""
-from typing import List, Dict, Any
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+
+import requests
+
+from src.config import WEB_SEARCH_API_KEY, WEB_SEARCH_API_ENDPOINT
+
+
+def _no_api_key_response(query: str) -> List[Dict[str, Any]]:
+    """Return a structured response when no API key is configured."""
+
+    return [
+        {
+            "title": "Web search API key not configured",
+            "snippet": (
+                "The WEB_SEARCH_API_KEY environment variable is missing. "
+                "Set it to enable real web searches."
+            ),
+            "url": "",
+            "source": "error",
+        }
+    ]
+
+
+def _rate_limited_response() -> List[Dict[str, Any]]:
+    """Return a structured response when the API rate limit is hit."""
+
+    return [
+        {
+            "title": "Web search rate limit exceeded",
+            "snippet": "The web search API rate limit has been reached. Try again later.",
+            "url": "",
+            "source": "error",
+        }
+    ]
+
+
+def _error_response(error: Exception) -> List[Dict[str, Any]]:
+    """Return a structured response for unexpected errors."""
+
+    return [
+        {
+            "title": "Web search error",
+            "snippet": str(error),
+            "url": "",
+            "source": "error",
+        }
+    ]
+
 
 def search_web(query: str, max_results: int = 5) -> List[Dict[str, Any]]:
-    """
-    Placeholder web search function
-    In production, this would integrate with a real web search API
-    
+    """Perform a web search using the configured provider.
+
     Args:
-        query: The search query
-        max_results: Maximum number of results to return
-        
+        query: The search query.
+        max_results: Maximum number of results to return.
+
     Returns:
-        List of search results
+        List of dictionaries with keys: title, snippet, url, source.
     """
-    # For now, return a message indicating web search is not implemented
-    # In production, this would use APIs like Bing, Google, or Serper
-    return [{
-        "title": "Web Search Not Implemented",
-        "snippet": f"Web search for '{query}' would be performed here. Please rely on knowledge base content for now.",
-        "url": "#",
-        "source": "placeholder"
-    }]
+
+    if not WEB_SEARCH_API_KEY:
+        return _no_api_key_response(query)
+
+    headers = {"X-API-KEY": WEB_SEARCH_API_KEY, "Content-Type": "application/json"}
+    payload = {"q": query, "num": max_results}
+
+    try:
+        response = requests.post(
+            WEB_SEARCH_API_ENDPOINT, headers=headers, json=payload, timeout=10
+        )
+
+        if response.status_code == 429:
+            return _rate_limited_response()
+
+        response.raise_for_status()
+        data = response.json()
+
+        results: List[Dict[str, Any]] = []
+        for item in data.get("organic", [])[:max_results]:
+            url = item.get("link", "")
+            results.append(
+                {
+                    "title": item.get("title", ""),
+                    "snippet": item.get("snippet", ""),
+                    "url": url,
+                    "source": urlparse(url).netloc if url else "",
+                }
+            )
+
+        if results:
+            return results
+
+        # No results returned from provider
+        return [
+            {
+                "title": "No results found",
+                "snippet": f"No web search results for '{query}'.",
+                "url": "",
+                "source": "serper",
+            }
+        ]
+
+    except requests.RequestException as exc:  # Covers HTTP and network errors
+        return _error_response(exc)
+
 
 def search_news(query: str, days_back: int = 30) -> List[Dict[str, Any]]:
-    """Search for recent news articles"""
+    """Search for recent news articles."""
+
     return search_web(f"{query} news last {days_back} days")
 
+
 def search_market_data(query: str) -> List[Dict[str, Any]]:
-    """Search for market data and statistics"""
+    """Search for market data and statistics."""
+
     return search_web(f"{query} market data statistics")
+

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,0 +1,80 @@
+"""Unit tests for the web search service."""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+# Ensure the src package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import src.services.web_search as web_search
+from src.services.web_search import search_web
+
+
+class MockResponse:
+    """Simple mock for requests.Response used in tests."""
+
+    def __init__(self, status_code: int, payload: Dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+def test_search_web_returns_results(monkeypatch):
+    """search_web should return structured results when the API succeeds."""
+
+    def mock_post(url, headers=None, json=None, timeout=10):
+        payload = {
+            "organic": [
+                {
+                    "title": "Example Domain",
+                    "snippet": "This domain is for use in illustrative examples.",
+                    "link": "https://example.com",
+                }
+            ]
+        }
+        return MockResponse(200, payload)
+
+    monkeypatch.setattr(web_search.requests, "post", mock_post)
+    monkeypatch.setattr(web_search, "WEB_SEARCH_API_KEY", "test")
+
+    results = search_web("example")
+    assert len(results) == 1
+    assert results[0]["title"] == "Example Domain"
+    assert results[0]["url"] == "https://example.com"
+    assert results[0]["source"] == "example.com"
+
+
+def test_search_web_handles_rate_limit(monkeypatch):
+    """search_web should handle API rate limiting gracefully."""
+
+    def mock_post(url, headers=None, json=None, timeout=10):
+        return MockResponse(429, {})
+
+    monkeypatch.setattr(web_search.requests, "post", mock_post)
+    monkeypatch.setattr(web_search, "WEB_SEARCH_API_KEY", "test")
+
+    results = search_web("rate limit test")
+    assert len(results) == 1
+    assert "rate limit" in results[0]["title"].lower()
+    assert results[0]["source"] == "error"
+
+
+def test_search_web_without_api_key(monkeypatch):
+    """search_web should warn when no API key is configured."""
+
+    monkeypatch.setattr(web_search, "WEB_SEARCH_API_KEY", "")
+
+    results = search_web("missing key")
+    assert len(results) == 1
+    assert "api key" in results[0]["title"].lower()
+    assert results[0]["source"] == "error"
+


### PR DESCRIPTION
## Summary
- integrate real web search service with configurable API endpoint and key
- normalize web search responses and handle missing key, rate limits, and errors
- add unit tests covering success, rate limiting, and missing API key scenarios

## Testing
- `python -m pytest tests/test_web_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6286bc930832e99bc77c77105ca39