### PR TITLE
Add caching and async concurrency to multi-agent pipeline

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,10 @@ load_dotenv()
 # Vector Store id for File Search (optional)
 VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID", "").strip() or None
 
+# Caching configuration
+CACHE_SIZE = int(os.getenv("CACHE_SIZE", "128"))
+CACHE_TTL = int(os.getenv("CACHE_TTL", "300"))
+
 # Default models (best-for-cost mix; override via .env)
 DEFAULT_MODELS = {
     "default": os.getenv("DEFAULT_MODEL", "gpt-5"),

--- a/src/services/web_search.py
+++ b/src/services/web_search.py
@@ -1,34 +1,35 @@
-"""
-Web Search Service
-Placeholder for web search functionality
-"""
+"""Web Search Service with simple caching."""
 from typing import List, Dict, Any
 
-def search_web(query: str, max_results: int = 5) -> List[Dict[str, Any]]:
-    """
-    Placeholder web search function
-    In production, this would integrate with a real web search API
-    
-    Args:
-        query: The search query
-        max_results: Maximum number of results to return
-        
-    Returns:
-        List of search results
-    """
-    # For now, return a message indicating web search is not implemented
-    # In production, this would use APIs like Bing, Google, or Serper
+from src.config import CACHE_SIZE, CACHE_TTL
+from src.utils.cache import Cache
+
+# Global cache for web search results
+web_cache = Cache(maxsize=CACHE_SIZE, ttl=CACHE_TTL)
+
+def _search_web_impl(query: str, max_results: int = 5) -> List[Dict[str, Any]]:
+    """Actual web search implementation placeholder."""
     return [{
         "title": "Web Search Not Implemented",
         "snippet": f"Web search for '{query}' would be performed here. Please rely on knowledge base content for now.",
         "url": "#",
-        "source": "placeholder"
+        "source": "placeholder",
     }]
 
+def search_web(query: str, max_results: int = 5) -> List[Dict[str, Any]]:
+    """Cached wrapper around web search implementation."""
+    key = (query, max_results)
+    cached = web_cache.get(key)
+    if cached is not None:
+        return cached
+    result = _search_web_impl(query, max_results)
+    web_cache.set(key, result)
+    return result
+
 def search_news(query: str, days_back: int = 30) -> List[Dict[str, Any]]:
-    """Search for recent news articles"""
+    """Search for recent news articles."""
     return search_web(f"{query} news last {days_back} days")
 
 def search_market_data(query: str) -> List[Dict[str, Any]]:
-    """Search for market data and statistics"""
+    """Search for market data and statistics."""
     return search_web(f"{query} market data statistics")

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -1,0 +1,37 @@
+import time
+from collections import OrderedDict
+from typing import Any, Hashable, Tuple
+
+class Cache:
+    """Simple TTL-based LRU cache."""
+    def __init__(self, maxsize: int = 128, ttl: int = 300) -> None:
+        self.maxsize = maxsize
+        self.ttl = ttl
+        self._store: OrderedDict[Hashable, Tuple[Any, float]] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, key: Hashable) -> Any:
+        now = time.time()
+        if key in self._store:
+            value, timestamp = self._store[key]
+            if now - timestamp < self.ttl:
+                self._store.move_to_end(key)
+                self.hits += 1
+                return value
+            else:
+                del self._store[key]
+        self.misses += 1
+        return None
+
+    def set(self, key: Hashable, value: Any) -> None:
+        if key in self._store:
+            del self._store[key]
+        elif len(self._store) >= self.maxsize:
+            self._store.popitem(last=False)
+        self._store[key] = (value, time.time())
+
+    def clear(self) -> None:
+        self._store.clear()
+        self.hits = 0
+        self.misses = 0

--- a/tests/test_cache_async.py
+++ b/tests/test_cache_async.py
@@ -1,0 +1,88 @@
+import asyncio
+import time
+from datetime import datetime
+
+from src.services import web_search
+from src.agents.multi_agent_base import BaseAgent, AgentMessage, MessageType, llm_cache
+from src.agents.team_leads import ResearchTeamLead
+
+
+class DummyAgent(BaseAgent):
+    def __init__(self):
+        super().__init__("dummy", "dummy")
+
+    def process_message(self, message: AgentMessage) -> AgentMessage:
+        return message
+
+    def validate_task(self, task, payload):
+        return True, "ok"
+
+
+def test_web_search_caching(monkeypatch):
+    web_search.web_cache.clear()
+    calls = {"count": 0}
+
+    def fake_impl(query: str, max_results: int = 5):
+        calls["count"] += 1
+        return [{"title": "res", "url": "#"}]
+
+    monkeypatch.setattr(web_search, "_search_web_impl", fake_impl)
+
+    first = web_search.search_web("alpha")
+    second = web_search.search_web("alpha")
+    assert calls["count"] == 1
+    assert first == second
+
+
+def test_query_llm_caching(monkeypatch):
+    llm_cache.clear()
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    agent = DummyAgent()
+    calls = {"count": 0}
+
+    def fake_response(*args, **kwargs):
+        calls["count"] += 1
+
+        class Resp:
+            def __init__(self):
+                self.output = type("o", (), {"message": type("m", (), {"content": "hello"})()})()
+                self.choices = []
+
+        return Resp()
+
+    monkeypatch.setattr(agent.responses_client, "create_response", fake_response)
+
+    t1 = agent.query_llm("hi")
+    t2 = agent.query_llm("hi")
+    assert calls["count"] == 1
+    assert t1 == t2 == "hello"
+
+
+def test_research_lead_concurrency(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("VECTOR_STORE_ID", "vs-test")
+    lead = ResearchTeamLead()
+
+    def slow_response(message):
+        time.sleep(0.2)
+        return AgentMessage(
+            from_agent="x",
+            to_agent=lead.agent_id,
+            message_type=MessageType.RESPONSE,
+            task="t",
+            payload={"sources": []},
+            context={},
+            timestamp=datetime.now().isoformat(),
+        )
+
+    monkeypatch.setattr(lead.web_researcher, "receive_message", slow_response)
+    monkeypatch.setattr(lead.kb_researcher, "receive_message", slow_response)
+    monkeypatch.setattr(lead.data_validator, "receive_message", lambda msg: slow_response(msg))
+    monkeypatch.setattr(ResearchTeamLead, "_extract_all_sources", lambda self, content: [])
+    monkeypatch.setattr(ResearchTeamLead, "_synthesize_findings", lambda self, t, c, v, s: "s")
+    monkeypatch.setattr(ResearchTeamLead, "_calculate_research_quality", lambda self, c, v: 0)
+
+    start = time.perf_counter()
+    asyncio.run(lead.coordinate_comprehensive_research({"topic": "x", "requirements": {"min_sources": 0}}))
+    duration = time.perf_counter() - start
+    assert duration < 0.45


### PR DESCRIPTION
## Summary
- introduce a simple TTL-based LRU cache and expose cache size/TTL config values
- cache web search results and LLM queries to avoid redundant API calls
- run research sub-agent web and knowledge base requests concurrently with `asyncio.gather`
- add tests demonstrating caching and faster concurrent execution

## Testing
- `PYTHONPATH=. pytest tests/test_cache_async.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a628708db4832e88956e7fd1525609