### PR TITLE
feat: add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ An automated system for generating high-quality learning center articles using O
    python scripts/generate_complete_article.py --topic "private equity trends"
    ```
 
+5. (Optional) Configure logging level:
+   ```bash
+   export LOG_LEVEL=DEBUG  # INFO by default
+   ```
+
 ## Project Structure
 
 ```
@@ -55,6 +60,12 @@ An automated system for generating high-quality learning center articles using O
 - **Dakota-Specific Knowledge**: Integrated Dakota Way methodology
 - **Quality Assurance**: Built-in validation and iteration
 - **Parallel Processing**: Efficient multi-step generation
+
+## Logging
+
+Logging uses the helper in `src/utils/logging.py`. Set the `LOG_LEVEL` environment
+variable (`DEBUG`, `INFO`, etc.) to control verbosity. Use `LOG_FORMAT=json` for
+JSON-formatted logs.
 
 ## Documentation
 

--- a/scripts/generate_multi_agent_article.py
+++ b/scripts/generate_multi_agent_article.py
@@ -12,6 +12,10 @@ import json
 
 from src.pipeline.multi_agent_orchestrator import generate_article_multi_agent
 from src.config import MIN_WORD_COUNT, OUTPUT_BASE_DIR
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def main():
@@ -39,78 +43,87 @@ def main():
     
     args = parser.parse_args()
     
-    print(f"\n{'='*60}")
-    print("🤖 MULTI-AGENT ARTICLE GENERATION")
-    print(f"{'='*60}")
-    print(f"Topic: {args.topic}")
-    print(f"Target: {args.word_count} words")
-    print(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-    print(f"{'='*60}")
+    logger.info("\n%s", '='*60)
+    logger.info("🤖 MULTI-AGENT ARTICLE GENERATION")
+    logger.info("%s", '='*60)
+    logger.info("Topic: %s", args.topic)
+    logger.info("Target: %s words", args.word_count)
+    logger.info("Time: %s", datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+    logger.info("%s", '='*60)
     
     try:
         # Generate article
         result = generate_article_multi_agent(args.topic, args.word_count)
         
         if result.get("success"):
-            print(f"\n✅ Article generated successfully!")
-            
+            logger.info("\n✅ Article generated successfully!")
+
             # Display results
-            print(f"\n📊 Results:")
-            print(f"   Word Count: {result['metrics']['word_count']}")
-            print(f"   Quality Score: {result['metrics']['quality_score']:.1f}/10")
-            print(f"   Generation Time: {result['metrics']['generation_time']:.1f} minutes")
-            
+            logger.info("\n📊 Results:")
+            logger.info("   Word Count: %s", result['metrics']['word_count'])
+            logger.info(
+                "   Quality Score: %.1f/10", result['metrics']['quality_score']
+            )
+            logger.info(
+                "   Generation Time: %.1f minutes",
+                result['metrics']['generation_time'],
+            )
+
             # Display files
-            print(f"\n📁 Output Files:")
+            logger.info("\n📁 Output Files:")
             for file_type, file_path in result['files'].items():
-                print(f"   {file_type}: {file_path}")
-            
+                logger.info("   %s: %s", file_type, file_path)
+
             # Display agent involvement
-            print(f"\n🤖 Agent Involvement:")
+            logger.info("\n🤖 Agent Involvement:")
             for agent_type, count in result['metrics']['agents_involved'].items():
-                print(f"   {agent_type}: {count} agents")
-            
+                logger.info("   %s: %s agents", agent_type, count)
+
             # Quality summary
             if 'quality_report' in result:
                 quality = result['quality_report']
-                print(f"\n✅ Quality Assessment:")
-                print(f"   Overall Score: {quality.get('overall_quality_score', 0):.1f}/10")
-                print(f"   Grade: {quality.get('quality_grade', 'N/A')}")
-                print(f"   Ready for Publication: {quality.get('ready_for_publication', False)}")
-                
+                logger.info("\n✅ Quality Assessment:")
+                logger.info(
+                    "   Overall Score: %.1f/10",
+                    quality.get('overall_quality_score', 0),
+                )
+                logger.info("   Grade: %s", quality.get('quality_grade', 'N/A'))
+                logger.info(
+                    "   Ready for Publication: %s",
+                    quality.get('ready_for_publication', False),
+                )
+
                 if quality.get('recommendations'):
-                    print(f"\n💡 Top Recommendations:")
+                    logger.info("\n💡 Top Recommendations:")
                     for i, rec in enumerate(quality['recommendations'][:3], 1):
-                        print(f"   {i}. {rec}")
-            
+                        logger.info("   %s. %s", i, rec)
+
             # Preview
-            print(f"\n📄 Article Preview:")
-            print(f"{'-'*60}")
-            print(result['article'][:500] + "...")
-            print(f"{'-'*60}")
-            
-            print(f"\n✨ Article saved to: {result['output_directory']}")
-            print(f"\n🎉 Success! View your article at:")
-            print(f"   {result['files']['article']}")
-            
+            logger.info("\n📄 Article Preview:")
+            logger.info("%s", '-'*60)
+            logger.info("%s...", result['article'][:500])
+            logger.info("%s", '-'*60)
+
+            logger.info("\n✨ Article saved to: %s", result['output_directory'])
+            logger.info("\n🎉 Success! View your article at:")
+            logger.info("   %s", result['files']['article'])
+
         else:
-            print(f"\n❌ Article generation failed!")
-            print(f"   Error: {result.get('error', 'Unknown error')}")
-            print(f"   Phase: {result.get('phase_failed', 'Unknown')}")
-            
+            logger.error("\n❌ Article generation failed!")
+            logger.error("   Error: %s", result.get('error', 'Unknown error'))
+            logger.error("   Phase: %s", result.get('phase_failed', 'Unknown'))
+
             if 'details' in result:
-                print(f"\n🔍 Error Details:")
-                print(json.dumps(result['details'], indent=2))
-            
+                logger.error("\n🔍 Error Details:")
+                logger.error(json.dumps(result['details'], indent=2))
+
             sys.exit(1)
             
     except KeyboardInterrupt:
-        print("\n\n⚠️ Generation interrupted by user")
+        logger.warning("\n\n⚠️ Generation interrupted by user")
         sys.exit(1)
     except Exception as e:
-        print(f"\n❌ Error: {str(e)}")
-        import traceback
-        traceback.print_exc()
+        logger.exception("\n❌ Error: %s", str(e))
         sys.exit(1)
 
 

--- a/src/agents/multi_agent_base.py
+++ b/src/agents/multi_agent_base.py
@@ -11,6 +11,10 @@ from dataclasses import dataclass, asdict
 
 from src.services.openai_responses_client import ResponsesClient
 from src.config import DEFAULT_MODELS
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class MessageType(Enum):
@@ -232,7 +236,7 @@ class BaseAgent(ABC):
             # If we can't extract content, return the whole response as string
             return str(response)
         except Exception as e:
-            print(f"LLM query error in {self.agent_id}: {str(e)}")
+            logger.error("LLM query error in %s: %s", self.agent_id, str(e))
             return f"Error: {str(e)}"
     
     def get_conversation_history(self, limit: int = 10) -> List[Dict[str, Any]]:

--- a/src/pipeline/multi_agent_orchestrator.py
+++ b/src/pipeline/multi_agent_orchestrator.py
@@ -12,6 +12,10 @@ from src.agents.orchestrator import OrchestratorAgent, create_article_with_multi
 from src.models import ArticleRequest, ArticleResponse, MetadataGeneration
 from src.config import OUTPUT_DIR, ARTICLE_CONFIG
 from src.utils import ensure_output_dir, format_article_filename
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class MultiAgentPipelineOrchestrator:
@@ -49,10 +53,10 @@ class MultiAgentPipelineOrchestrator:
             custom_instructions=custom_instructions
         )
         
-        print(f"\n🤖 Multi-Agent System: Generating article on '{topic}'")
-        print(f"   Audience: {request.audience}")
-        print(f"   Tone: {request.tone}")
-        print(f"   Target length: ~{request.word_count} words")
+        logger.info("\n🤖 Multi-Agent System: Generating article on '%s'", topic)
+        logger.info("   Audience: %s", request.audience)
+        logger.info("   Tone: %s", request.tone)
+        logger.info("   Target length: ~%s words", request.word_count)
         
         try:
             # Generate article using multi-agent system
@@ -73,16 +77,19 @@ class MultiAgentPipelineOrchestrator:
                     "timestamp": datetime.now().isoformat()
                 }
                 
-                print(f"\n✅ Article generated successfully!")
-                print(f"   Output: {output_path}")
-                print(f"   Word count: {result['word_count']}")
+                logger.info("\n✅ Article generated successfully!")
+                logger.info("   Output: %s", output_path)
+                logger.info("   Word count: %s", result['word_count'])
                 if 'quality_score' in result.get('quality_metrics', {}):
-                    print(f"   Quality score: {result['quality_metrics']['quality_score']}/100")
+                    logger.info(
+                        "   Quality score: %s/100",
+                        result['quality_metrics']['quality_score'],
+                    )
                 
                 return result
             else:
                 error_msg = getattr(response, 'error', 'Unknown error in multi-agent system')
-                print(f"\n❌ Article generation failed: {error_msg}")
+                logger.error("\n❌ Article generation failed: %s", error_msg)
                 return {
                     "success": False,
                     "error": error_msg,
@@ -91,7 +98,7 @@ class MultiAgentPipelineOrchestrator:
                 }
                 
         except Exception as e:
-            print(f"\n❌ Error in multi-agent pipeline: {str(e)}")
+            logger.error("\n❌ Error in multi-agent pipeline: %s", str(e))
             return {
                 "success": False,
                 "error": str(e),
@@ -195,9 +202,9 @@ def main():
     ]
     
     for topic in topics[:1]:  # Generate one article as example
-        print(f"\n{'='*60}")
-        print(f"Generating article with Multi-Agent System")
-        print(f"{'='*60}")
+        logger.info("\n%s", '='*60)
+        logger.info("Generating article with Multi-Agent System")
+        logger.info("%s", '='*60)
         
         result = orchestrator.generate_article(
             topic=topic,
@@ -205,17 +212,19 @@ def main():
         )
         
         if result["success"]:
-            print(f"\n📄 Article Preview:")
-            print(f"{'-'*60}")
-            print(result["article"][:500] + "...")
-            print(f"{'-'*60}")
-            
+            logger.info("\n📄 Article Preview:")
+            logger.info("%s", '-'*60)
+            logger.info("%s...", result["article"][:500])
+            logger.info("%s", '-'*60)
+
             # Show system status
             status = orchestrator.get_system_status()
-            print(f"\n🔍 System Status:")
-            print(f"   Orchestrator: {status.get('orchestrator_status', 'Unknown')}")
-            print(f"   Agents active: {len(status.get('agent_statuses', {}))}")
-            print(f"   Pipelines completed: {status.get('pipelines_completed', 0)}")
+            logger.info("\n🔍 System Status:")
+            logger.info("   Orchestrator: %s", status.get('orchestrator_status', 'Unknown'))
+            logger.info("   Agents active: %s", len(status.get('agent_statuses', {})))
+            logger.info(
+                "   Pipelines completed: %s", status.get('pipelines_completed', 0)
+            )
 
 
 def generate_article_multi_agent(topic: str, word_count: int = 2000, **kwargs) -> Dict[str, Any]:
@@ -288,3 +297,4 @@ def generate_article_multi_agent(topic: str, word_count: int = 2000, **kwargs) -
 
 if __name__ == "__main__":
     main()
+

--- a/src/services/openai_responses_client.py
+++ b/src/services/openai_responses_client.py
@@ -6,16 +6,20 @@ import os
 from typing import Dict, Any, Optional, List
 from openai import OpenAI
 from dotenv import load_dotenv
+from src.utils.logging import get_logger
 
 load_dotenv()
+
+logger = get_logger(__name__)
 
 
 class ResponsesClient:
     """Wrapper for OpenAI Responses API with GPT-5 support"""
-    
+
     def __init__(self):
         self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         self.previous_response_id = None
+        logger.debug("ResponsesClient initialized")
     
     def create_response(
         self,
@@ -46,6 +50,7 @@ class ResponsesClient:
         Returns:
             Response dictionary
         """
+        logger.debug("Creating response with model %s", model)
         request_data = {
             "model": model,
             "input": input_text,
@@ -79,6 +84,7 @@ class ResponsesClient:
         
         # Make the API call
         response = self.client.responses.create(**request_data)
+        logger.debug("Response received")
         
         # Store response ID for next turn
         if hasattr(response, 'id'):
@@ -98,6 +104,7 @@ class ResponsesClient:
         
         Returns just the text content
         """
+        logger.debug("Creating simple response with model %s", model)
         response = self.create_response(
             model=model,
             input_text=prompt,
@@ -119,3 +126,4 @@ class ResponsesClient:
     def reset_conversation(self):
         """Reset the conversation by clearing previous response ID"""
         self.previous_response_id = None
+        logger.debug("Conversation reset")

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,0 +1,46 @@
+import os
+import json
+import logging as _logging
+from typing import Optional
+
+
+class _JsonFormatter(_logging.Formatter):
+    """Format logs as JSON objects."""
+
+    def format(self, record: _logging.LogRecord) -> str:
+        log_record = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def get_logger(name: Optional[str] = None) -> _logging.Logger:
+    """Return a configured logger.
+
+    Log level is controlled by the ``LOG_LEVEL`` environment variable and the
+    format by ``LOG_FORMAT`` (``plain`` or ``json``). Defaults to ``INFO`` level
+    and plain text formatting.
+    """
+    logger = _logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(_logging, level_name, _logging.INFO)
+    logger.setLevel(level)
+
+    handler = _logging.StreamHandler()
+    log_format = os.getenv("LOG_FORMAT", "plain").lower()
+    if log_format == "json":
+        formatter = _JsonFormatter()
+    else:
+        formatter = _logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger


### PR DESCRIPTION
## Summary
- add centralized `get_logger` helper for consistent, env-configurable logging
- replace print statements in orchestrator, base agent, responses client, and generator script with logger calls
- document how to adjust log levels

## Testing
- `pytest -q` *(fails: missing modules and OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a62a416e8c832e8993e3f4c69ffeac