### PR TITLE
Handle empty sources in DataValidationAgent credibility check

### DIFF
--- a/src/agents/research_agents.py
+++ b/src/agents/research_agents.py
@@ -601,6 +601,18 @@ Return structured validation results."""
     
     def _check_source_credibility(self, sources: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Check credibility of sources"""
+        # Return early if no sources are provided
+        if not sources:
+            return {
+                "success": False,
+                "error": "No sources provided",
+                "sources_checked": 0,
+                "average_credibility": 0,
+                "results": [],
+                "highly_credible": [],
+                "low_credibility": [],
+            }
+
         credibility_results = []
         
         for source in sources:
@@ -622,7 +634,11 @@ Return structured validation results."""
             credibility_results.append(result)
         
         # Overall assessment
-        avg_credibility = sum(r["credibility_score"] for r in credibility_results) / len(credibility_results)
+        avg_credibility = (
+            sum(r["credibility_score"] for r in credibility_results) / len(credibility_results)
+            if credibility_results
+            else 0
+        )
         
         return {
             "success": True,

--- a/tests/test_data_validation_agent.py
+++ b/tests/test_data_validation_agent.py
@@ -1,0 +1,16 @@
+import sys
+import pathlib as _pathlib
+
+sys.path.append(str(_pathlib.Path(__file__).resolve().parent.parent))
+
+from src.agents.research_agents import DataValidationAgent
+
+
+def test_check_source_credibility_empty_sources(mock_openai):
+    agent = DataValidationAgent()
+    result = agent._check_source_credibility([])
+    assert result["success"] is False
+    assert result["average_credibility"] == 0
+    assert result["sources_checked"] == 0
+    assert result["results"] == []
+    assert "No sources" in result.get("error", "")


### PR DESCRIPTION
## Summary
- Safely handle empty source lists in `DataValidationAgent._check_source_credibility`
- Avoid divide-by-zero by computing average credibility only when results exist
- Add unit test verifying graceful handling of empty source input

## Testing
- `pytest tests/test_data_validation_agent.py -q`
- `pytest tests/test_content_writer.py -q` *(fails: LLMAPIError: Mock API error)*

------
https://chatgpt.com/codex/tasks/task_e_68a724ac5234832e81b0bf74b9745d78