### PR TITLE
Make ResearchTeamLead async and await orchestration

### DIFF
--- a/src/agents/orchestrator.py
+++ b/src/agents/orchestrator.py
@@ -91,9 +91,6 @@ class OrchestratorAgent(BaseAgent):
         payload = message.payload
         
         if task == "generate_article":
-            # Use nest_asyncio to handle nested event loops
-            import nest_asyncio
-            nest_asyncio.apply()
             result = asyncio.run(self._orchestrate_article_generation(payload["request"]))
         elif task == "review_pipeline":
             result = self._review_current_pipeline()
@@ -211,8 +208,8 @@ class OrchestratorAgent(BaseAgent):
         await asyncio.sleep(0.5)  # Simulate processing time
         
         # Process response
-        response = self.research_lead.receive_message(research_msg)
-        
+        response = await self.research_lead.receive_message(research_msg)
+
         if response:
             logger.info(f"Research response received: {response.payload.get('success', False)}")
             if not response.payload.get('success', False):

--- a/tests/test_orchestrator_api_failure.py
+++ b/tests/test_orchestrator_api_failure.py
@@ -27,12 +27,8 @@ def test_orchestrator_handles_api_failure(monkeypatch):
         mock_create_response,
     )
     monkeypatch.setattr(
-        "src.services.kb_search.KnowledgeBaseSearcher.__init__",
-        lambda self: None,
-    )
-    monkeypatch.setattr(
-        "src.services.kb_search.KnowledgeBaseSearcher.search",
-        lambda self, query: {"success": False, "results": []},
+        "src.services.kb_search_optimized.get_kb_searcher",
+        lambda: type("Dummy", (), {"search": lambda self, q, **k: {"success": False, "results": []}})(),
     )
 
     orchestrator = OrchestratorAgent()


### PR DESCRIPTION
## Summary
- support async `ResearchTeamLead.process_message` and run sub-researchers concurrently
- allow `BaseAgent.receive_message` to run async handlers within existing event loops
- orchestrator now awaits the research lead and tests updated for async behavior

## Testing
- `pytest tests/test_async_performance.py tests/test_orchestrator_api_failure.py`


------
https://chatgpt.com/codex/tasks/task_e_68a724adf8ec832e8ae287d26d0ceef5