### PR TITLE
chore: remove unused VectorStoreHandler import

### DIFF
--- a/src/pipeline/base_orchestrator.py
+++ b/src/pipeline/base_orchestrator.py
@@ -9,7 +9,6 @@ from openai import OpenAI
 from typing import Dict, Any, Optional
 from dotenv import load_dotenv
 
-from src.tools.vector_store_handler import VectorStoreHandler
 from src.services.openai_responses_client import ResponsesClient
 from src.services.kb_search import KnowledgeBaseSearcher
 from src.config import DEFAULT_MODELS, OUTPUT_BASE_DIR


### PR DESCRIPTION
## Summary
- drop unused `VectorStoreHandler` import from `BaseOrchestrator`

## Testing
- `ruff check --select F401 src/pipeline/base_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_68a72d7da524832e8a9ae19da268362c