### PR TITLE
Refactor async coordination in ResearchTeamLead

### DIFF
--- a/src/agents/team_leads.py
+++ b/src/agents/team_leads.py
@@ -67,10 +67,7 @@ class ResearchTeamLead(BaseAgent):
         payload = message.payload
 
         if task == "comprehensive_research":
-            # Handle async execution properly - avoid nested event loops
-            import nest_asyncio
-            nest_asyncio.apply()
-            result_model = asyncio.run(self._coordinate_comprehensive_research_async(payload))
+            result_model = await self._coordinate_comprehensive_research_async(payload)
             result = result_model.model_dump()
         elif task == "validate_article":
             result = self._coordinate_article_validation(payload)
@@ -116,14 +113,14 @@ class ResearchTeamLead(BaseAgent):
         )
         
         # Execute all searches simultaneously with timeout protection
-        web_task = asyncio.create_task(
-            asyncio.wait_for(self.web_researcher.receive_message(web_msg), timeout=15)
+        web_task = asyncio.wait_for(
+            asyncio.to_thread(self.web_researcher.receive_message, web_msg), timeout=15
         )
-        kb_task = asyncio.create_task(
-            asyncio.wait_for(self.kb_researcher.receive_message(kb_msg), timeout=10)
+        kb_task = asyncio.wait_for(
+            asyncio.to_thread(self.kb_researcher.receive_message, kb_msg), timeout=10
         )
-        dakota_task = asyncio.create_task(
-            asyncio.wait_for(self.kb_researcher.receive_message(dakota_msg), timeout=10)
+        dakota_task = asyncio.wait_for(
+            asyncio.to_thread(self.kb_researcher.receive_message, dakota_msg), timeout=10
         )
 
         # Wait for all to complete


### PR DESCRIPTION
## Summary
- avoid nested event loops by awaiting `_coordinate_comprehensive_research_async`
- run research sub-agents concurrently using `asyncio.to_thread` with `asyncio.wait_for`

## Testing
- `pytest` *(fails: missing modules and API key)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f1b7444832ea0d45428238d759f