### PR TITLE
Validate research phase output before article generation continues

### DIFF
--- a/src/agents/orchestrator.py
+++ b/src/agents/orchestrator.py
@@ -124,10 +124,22 @@ class OrchestratorAgent(BaseAgent):
             # Phase 1: Research
             research_result = await self._phase_research(request)
             self.current_pipeline["phases"]["research"] = research_result
-            
+            if not isinstance(research_result, dict):
+                logger.error(
+                    "Research phase returned invalid result type: "
+                    f"{type(research_result).__name__}"
+                )
+                return self._pipeline_failed(
+                    "Research phase failed: invalid result format",
+                    {"result": research_result},
+                )
+
             if not research_result.get("success", False):
+                logger.error(
+                    f"Research phase unsuccessful: {research_result.get('error', 'Unknown error')}"
+                )
                 return self._pipeline_failed("Research phase failed", research_result)
-            
+
             # Phase 2: Writing
             writing_result = await self._phase_writing(request, research_result)
             self.current_pipeline["phases"]["writing"] = writing_result


### PR DESCRIPTION
## Summary
- Ensure orchestrator verifies research phase returns a dict with success flag before proceeding
- Log detailed errors when research results are invalid or unsuccessful to aid debugging

## Testing
- `pytest` *(fails: ImportError, missing modules / API key requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f1c33ac832e8b987899e595abd7