### PR TITLE
Validate metadata before publishing

### DIFF
--- a/src/agents/orchestrator.py
+++ b/src/agents/orchestrator.py
@@ -157,22 +157,27 @@ class OrchestratorAgent(BaseAgent):
                 request
             )
             self.current_pipeline["phases"]["publishing"] = publishing_result
-            
+
+            if not publishing_result.get("success", False):
+                return self._pipeline_failed("Publishing phase failed", publishing_result)
+
             # Stop broker
             self.broker.stop()
-            
+
             # Complete pipeline
             self.current_pipeline["status"] = "completed"
             self.current_pipeline["end_time"] = datetime.now().isoformat()
             self.pipeline_history.append(self.current_pipeline)
-            
+
             self.update_status(AgentStatus.COMPLETED, "Article generation complete")
-            
+
+            publication_package = publishing_result.get("publication_package", {})
+
             return {
                 "success": True,
                 "pipeline_id": pipeline_id,
-                "article": publishing_result["final_article"],
-                "metadata": publishing_result["metadata"],
+                "article": publication_package.get("article", ""),
+                "metadata": publication_package.get("metadata", {}),
                 "quality_score": quality_result.get("overall_quality_score", 0),
                 "phases_completed": list(self.current_pipeline["phases"].keys()),
                 "total_time": self._calculate_pipeline_duration()
@@ -318,7 +323,7 @@ class OrchestratorAgent(BaseAgent):
         # Send to publishing team lead
         publishing_msg = self.send_message(
             to_agent=self.publishing_lead.agent_id,
-            task="prepare_for_publication",
+            task="prepare_publication",
             payload={
                 "article": article,
                 "metadata": {
@@ -336,7 +341,7 @@ class OrchestratorAgent(BaseAgent):
         await asyncio.sleep(0.5)
         
         response = self.publishing_lead.receive_message(publishing_msg)
-        
+
         return response.payload if response else {"success": False, "error": "No response from publishing team"}
     
     def _review_current_pipeline(self) -> Dict[str, Any]:
@@ -491,27 +496,35 @@ def create_article_with_multi_agent_system(request: ArticleRequest) -> ArticleRe
     
     if response.payload.get("success", False):
         # Map fields that might have different names
-        metadata_dict = response.payload["metadata"].copy()
-        
+        metadata_dict = response.payload.get("metadata", {}).copy()
+
         # Handle field name variations
         if "target_keywords" in metadata_dict and "keywords" not in metadata_dict:
             metadata_dict["keywords"] = metadata_dict.pop("target_keywords")
         if "meta_description" in metadata_dict and "seo_description" not in metadata_dict:
             metadata_dict["seo_description"] = metadata_dict.pop("meta_description")
-        
-        # Ensure required fields have defaults
+
+        required_fields = ["keywords", "read_time_minutes", "key_takeaways"]
+        missing = [f for f in required_fields if not metadata_dict.get(f)]
+        if missing:
+            return ArticleResponse(
+                success=False,
+                article="",
+                metadata=None,
+                error=f"Missing required metadata fields: {', '.join(missing)}"
+            )
+
+        # Ensure required fields have defaults for optional values
         metadata_dict.setdefault("description", metadata_dict.get("seo_description", ""))
         metadata_dict.setdefault("category", "Investment Insights")
         metadata_dict.setdefault("target_audience", "institutional investors")
-        metadata_dict.setdefault("read_time_minutes", 7)
-        metadata_dict.setdefault("key_takeaways", [])
         metadata_dict.setdefault("related_topics", [])
         metadata_dict.setdefault("seo_title", metadata_dict.get("title", ""))
         metadata_dict.setdefault("publication_date", datetime.now().strftime("%Y-%m-%d"))
-        
+
         return ArticleResponse(
             success=True,
-            article=response.payload["article"],
+            article=response.payload.get("article", ""),
             metadata=MetadataGeneration(**metadata_dict),
             quality_metrics={
                 "quality_score": response.payload.get("quality_score", 0),
@@ -523,18 +536,6 @@ def create_article_with_multi_agent_system(request: ArticleRequest) -> ArticleRe
         return ArticleResponse(
             success=False,
             article="",
-            metadata=MetadataGeneration(
-                title="Generation Failed",
-                description="Article generation failed",
-                keywords=[],
-                category="Error",
-                target_audience="N/A",
-                read_time_minutes=0,
-                key_takeaways=[],
-                related_topics=[],
-                seo_title="Generation Failed",
-                seo_description="Article generation failed",
-                publication_date=datetime.now().strftime("%Y-%m-%d")
-            ),
+            metadata=None,
             error=response.payload.get("error", "Unknown error")
         )

--- a/tests/test_publishing_metadata_validation.py
+++ b/tests/test_publishing_metadata_validation.py
@@ -1,0 +1,54 @@
+import sys
+import pathlib as _pathlib
+sys.path.append(str(_pathlib.Path(__file__).resolve().parent.parent))
+
+from src.agents.team_leads import PublishingTeamLead
+from src.agents.orchestrator import OrchestratorAgent
+from src.agents.multi_agent_base import AgentMessage, MessageType
+from src.models import ArticleRequest
+
+
+def test_metadata_generation_missing_fields(monkeypatch, mock_openai):
+    lead = PublishingTeamLead()
+    monkeypatch.setattr(PublishingTeamLead, "query_llm", lambda self, *args, **kwargs: "title: Sample\nDescription: Desc")
+    result = lead._generate_comprehensive_metadata("content", {})
+    assert not result["success"]
+    assert "keywords" in result["error"]
+
+
+def test_orchestrator_reports_invalid_metadata(monkeypatch, mock_openai):
+    orchestrator = OrchestratorAgent()
+
+    async def _mock_research(self, request):
+        return {"success": True}
+
+    async def _mock_writing(self, request, research):
+        return {"success": True, "article": "content"}
+
+    async def _mock_quality(self, article):
+        return {"ready_for_publication": True, "approved_article": article}
+
+    monkeypatch.setattr(OrchestratorAgent, "_phase_research", _mock_research)
+    monkeypatch.setattr(OrchestratorAgent, "_phase_writing", _mock_writing)
+    monkeypatch.setattr(OrchestratorAgent, "_phase_quality_check", _mock_quality)
+
+    monkeypatch.setattr(PublishingTeamLead, "query_llm", lambda self, *args, **kwargs: "title: Sample")
+    monkeypatch.setattr(PublishingTeamLead, "_optimize_for_seo", lambda self, *args, **kwargs: {"optimized_content": "content", "seo_data": {}, "seo_score": 0})
+    monkeypatch.setattr(PublishingTeamLead, "_create_social_media_content", lambda self, *args, **kwargs: {"social_content": [], "platforms_covered": [], "estimated_engagement": 0})
+    monkeypatch.setattr(PublishingTeamLead, "_calculate_metadata_completeness", lambda self, metadata: 0.0)
+
+    request = ArticleRequest(topic="Test Topic")
+    message = AgentMessage(
+        from_agent="tester",
+        to_agent=orchestrator.agent_id,
+        message_type=MessageType.REQUEST,
+        task="generate_article",
+        payload={"request": request},
+        context={},
+        timestamp="",
+    )
+
+    response = orchestrator.receive_message(message)
+    assert not response.payload["success"]
+    assert "publishing phase failed" in response.payload["error"].lower()
+    assert "missing required metadata" in response.payload["details"].get("error", "").lower()


### PR DESCRIPTION
## Summary
- ensure PublishingTeamLead verifies metadata includes keywords, read_time_minutes, and key_takeaways
- make orchestrator abort when publishing metadata is invalid and avoid constructing MetadataGeneration on errors
- add tests covering metadata validation and pipeline failure handling

## Testing
- `pytest tests/test_publishing_metadata_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a742de3940832e82c29148f12b111c