### PR TITLE
Add research summarization helper for writing phase

### DIFF
--- a/TEST_ARTICLE_GENERATION.txt
+++ b/TEST_ARTICLE_GENERATION.txt
@@ -75,6 +75,7 @@ WHAT THE SYSTEM DOES
 
 2. Writing Phase:
    - Creates comprehensive article structure
+   - Uses condensed research summary (synthesis + top sources) capped at 1500 characters
    - Adds proper citations (min 10 sources)
    - Applies Dakota institutional style
    - Targets specified word count


### PR DESCRIPTION
## Summary
- Add `_summarize_research` helper to condense synthesis and top sources for writers
- Orchestrator uses condensed research summary when coordinating writing phase
- Document writing phase behavior and token cap in test instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a77bf90b28832e8841c4d0d347dbc7